### PR TITLE
Add ability to include arbitrary inline script in buildDom for nyc

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,7 @@ class WebExtensionsJSDOM {
       } else {
         dom = new jsdom.JSDOM(this.htmlTemplate(scripts), jsdomOptions);
       }
+      if (options.script) { dom.window.eval(options.script); }
     } else {
       dom = await this.nyc.buildDom(options, scripts, jsdomOptions);
     }

--- a/src/nyc.js
+++ b/src/nyc.js
@@ -52,6 +52,8 @@ class nyc {
       scriptsSource += ";\n;";
     }
 
+    if (options.script) { scriptsSource += `${options.script}`; }
+
     let refireStatechangeEvents = dom.window.document.readyState === 'complete';
 
     dom.window.eval(scriptsSource);


### PR DESCRIPTION
In my tests for some of my pull requests in https://github.com/mozilla/multi-account-containers/ I have previously been able to run `popup.window.eval("someVariableName")` in order to get access to a variable declared in the popup's script file. Unfortunately, now that `multi-account-containers` has been migrated to `webextensions-jsdom` and `nyc`, this technique no longer works. It seems that immediately after this line https://github.com/stoically/webextensions-jsdom/blob/89a35ee92cc0166e2d465b73a0ccd2d739bd3cd7/src/nyc.js#L57 the `eval` function of the `window` object is changed permanently, and can no longer be used to access script variables.

This pull request adds the ability to pass in arbitrary javascript code to execute during that first `eval` of the popup's script sources, when the `eval` method is still able to get access to variables defined in those same script sources.

With this change in place, I am able to get my tests working again by adding extra configuration to https://github.com/mozilla/multi-account-containers/blob/dc9e8f6399ffc1d434254a56ab64cb20a77e6cd4/test/helper.js#L13 as follows:

```
popup: {
    script: "function evalScript(v) { return eval(v); }",
    jsdom: {
        /* etc. */
    }
}
```

Then in my test scripts I can get hold of the popup's `Logic` variable by doing:

```
const Logic = popup.window.evalScript("Logic");
```
